### PR TITLE
[Funcionalidade] Workflow para deploy da UI do Swagger usando GitHub Pages

### DIFF
--- a/.github/workflows/swagger-ui.yml
+++ b/.github/workflows/swagger-ui.yml
@@ -1,0 +1,25 @@
+name: Deploy Swagger UI to GitHub Pages
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Generate Swagger UI
+        uses: Legion2/swagger-ui-action@v1
+        with:
+          output: swagger-ui
+          spec-file: openapi.yaml
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: swagger-ui


### PR DESCRIPTION
Olá,

Gostaria de propor o uso de um workflow do GitHub para gerar uma página Swagger com a documentação dos endpoints. Esse workflow usa a action [https://github.com/marketplace/actions/swagger-ui-action](https://github.com/marketplace/actions/swagger-ui-action) para gerar a página com base no arquivo `openapi.yaml` e faz o deploy dos artefatos para a branch `gh-pages`. Após o primeiro deploy é necessário apontar a branch `gh-pages` como origem na página de configurações do repositório [https://github.com/bacen/pix-api/settings](https://github.com/bacen/pix-api/settings). A página gerada ficará disponível em [https://bacen.github.io/pix-api](https://bacen.github.io/pix-api) e será similar a essa gerada no meu fork [https://vandreleal.github.io/pix-api](https://vandreleal.github.io/pix-api)

![ghpages](https://user-images.githubusercontent.com/9258892/97801697-49a34c00-1c1d-11eb-8bd4-e457a108a368.PNG)

