### PR TITLE
Altera referência para branch main

### DIFF
--- a/.github/workflows/swagger-ui.yml
+++ b/.github/workflows/swagger-ui.yml
@@ -2,7 +2,7 @@ name: Swagger UI -> GitHub Pages
 on:
   push:
     branches:
-      - master
+      - main
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-[![https://img.shields.io/badge/OpenAPI-valid-brightgreen.svg](https://img.shields.io/badge/OpenAPI-valid-brightgreen.svg)](http://online.swagger.io/validator?url=https://raw.githubusercontent.com/bacen/pix-api/master/openapi.yaml) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
+[![https://img.shields.io/badge/OpenAPI-valid-brightgreen.svg](https://img.shields.io/badge/OpenAPI-valid-brightgreen.svg)](http://online.swagger.io/validator?url=https://raw.githubusercontent.com/bacen/pix-api/main/openapi.yaml) [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 
 # [Especificação da API Pix](https://bacen.github.io/pix-api/index.html)
 
@@ -8,7 +8,7 @@
 
 # Link para visualização da API Pix
 
-O branch `master` da API pode ser visualizado __[aqui](https://bacen.github.io/pix-api/index.html)__
+O branch `main` da API pode ser visualizado __[aqui](https://bacen.github.io/pix-api/index.html)__
 
 # Release Corrente: 2.1.2
 


### PR DESCRIPTION
Não apenas Github como diversas outras grandes empresas estão migrando seu branch principal de `master` para `main`. Essa iniciativa vem acompanhada de uma reformulação de vocabulário de boa parcela da comunidade de tecnologia com a intenção de evitar o uso certos termos que possam fazer alusão a escravidão. O procedimento tende a ser muito simples, neste caso específico: após aprovação deste PR, criar o branch `main` no commit do merge e alterar em `Settings` para o branch default ser `main` invés de `master`