### PR TITLE
Remove atributo redundante do schema `CobVGerado`

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -4048,7 +4048,7 @@ components:
         - type: "object"
           properties:
             loc:
-              required: ["id", "txid", "tipoCob", "criacao"]
+              required: ["id", "tipoCob", "criacao"]
               allOf:
                 - $ref: "#/components/schemas/PayloadLocation"
         - type: "object"


### PR DESCRIPTION
A propriedade `txid` do atributo em `#/components.schemas.CobVGerada.allOf[3].properties.loc` é desnecessária já que o schema referenciado `PayloadLocation` não contém esse atributo.

Parece ser sido introduzido há algum tempo em https://github.com/bacen/pix-api/commit/d302e9e4d219d8f94fc934c2e20d0f68c254a2d5.